### PR TITLE
fix: title opts for notify_once

### DIFF
--- a/lua/gitsigns-yadm/init.lua
+++ b/lua/gitsigns-yadm/init.lua
@@ -47,14 +47,16 @@ function M.yadm_signs(callback)
         if M.config.homedir == nil then
             vim.notify_once(
                 'Could not determine $HOME, pass your home directory to setup() like:\nrequire("gitsigns-yadm").setup({ homedir = "/home/your_name" })',
-                vim.log.levels.WARN
+                vim.log.levels.WARN,
+                { title = 'gitsigns-yadm.nvim' }
             )
             return callback()
         end
         if M.config.yadm_repo_git == nil then
             vim.notify_once(
                 'Could not determine location of yadm repo, pass it to setup() like:\nrequire("gitsigns-yadm").setup({ yadm_repo_git = "~/path/to/repo.git" })',
-                vim.log.levels.WARN
+                vim.log.levels.WARN,
+                { title = 'gitsigns-yadm.nvim' }
             )
             return callback()
         end


### PR DESCRIPTION
title is used by 3rd party plugins like [rcarriga/nvim-notify](https://github.com/rcarriga/nvim-notify)

* Without `title`
    ![image](https://github.com/seanbreckenridge/gitsigns-yadm.nvim/assets/1279477/177093bd-6368-4d22-b2d6-ce4fec659c12)

* With `title`
    ![image](https://github.com/seanbreckenridge/gitsigns-yadm.nvim/assets/1279477/4d26929c-e2db-477c-b276-df3933568dbe)
